### PR TITLE
double the amount of data to receive

### DIFF
--- a/stitches/expect.py
+++ b/stitches/expect.py
@@ -45,7 +45,7 @@ class Expect(object):
         count = 0
         while count < timeout:
             try:
-                recv_part = connection.channel.recv(16384)
+                recv_part = connection.channel.recv(32768)
                 logging.getLogger('stitches.expect').debug("RCV: " + recv_part)
                 if connection.output_shell:
                     sys.stdout.write(recv_part)
@@ -113,7 +113,7 @@ class Expect(object):
         count = 0
         while count < timeout:
             try:
-                recv_part = connection.channel.recv(16384)
+                recv_part = connection.channel.recv(32768)
                 logging.getLogger('stitches.expect').debug("RCV: " + recv_part)
                 if connection.output_shell:
                     sys.stdout.write(recv_part)


### PR DESCRIPTION
The RHUI QE team has a new entitlement certificate which provides access to a huge number of repositories. Unfortunately, the number is so large that our test cases that use the match() and expect_list() functions from the stitches library no longer work. I'd like to fix that by increasing the amount of data in connection.channel.recv(); specifically, by changing 16384 to 32768 (since https://docs.python.org/2/library/socket.html suggests using powers of 2 with recv()). I've tested this change successfully.