### PR TITLE
python 3 compatibility fixes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@
 from setuptools import setup
 
 setup(name='stitches',
-    version='0.11',
+    version='0.12',
     description='Multihost actions toolbox',
     author='Vitaly Kuznetsov',
     author_email='vitty@redhat.com',

--- a/stitches/connection.py
+++ b/stitches/connection.py
@@ -55,7 +55,7 @@ class Connection(object):
         """
         self.logger = logging.getLogger('stitches.connection')
 
-        if type(instance) in (str, unicode):
+        if type(instance) == str:
             self.parameters = {'private_hostname': instance,
                                'public_hostname': instance}
         else:
@@ -136,7 +136,7 @@ class Connection(object):
         count = 0
         while count < 10:
             try:
-                recv_part = chan.recv(16384)
+                recv_part = chan.recv(16384).decode()
                 result += recv_part
             except socket.timeout:
                 # socket.timeout here means 'no more data'
@@ -212,7 +212,7 @@ t.start()
 
                 return rpyc.classic.ssh_connect(self.pbm, port)
 
-            except Exception, err:
+            except Exception as err:
                 self.logger.debug("Failed to setup rpyc: %s" % err)
                 return None
         else:
@@ -291,7 +291,7 @@ t.start()
         self.last_command = command
         stdin, stdout, stderr = self.cli.exec_command(command, get_pty=get_pty)
         if stdout and stderr and stdin:
-            for _ in xrange(timeout):
+            for _ in range(timeout):
                 if stdout.channel.exit_status_ready():
                     status = stdout.channel.recv_exit_status()
                     break

--- a/stitches/expect.py
+++ b/stitches/expect.py
@@ -45,7 +45,7 @@ class Expect(object):
         count = 0
         while count < timeout:
             try:
-                recv_part = connection.channel.recv(32768)
+                recv_part = connection.channel.recv(32768).decode()
                 logging.getLogger('stitches.expect').debug("RCV: " + recv_part)
                 if connection.output_shell:
                     sys.stdout.write(recv_part)
@@ -113,7 +113,7 @@ class Expect(object):
         count = 0
         while count < timeout:
             try:
-                recv_part = connection.channel.recv(32768)
+                recv_part = connection.channel.recv(32768).decode()
                 logging.getLogger('stitches.expect').debug("RCV: " + recv_part)
                 if connection.output_shell:
                     sys.stdout.write(recv_part)


### PR DESCRIPTION
Just a few minor fixes to make stitches usable with python 3. Tested using rhui3-automation, all looks well. Tested also with python 2.6 and 2.7 to check for possible regressions on these older versions, none found.