### PR TITLE
help to understand why a command failed

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,17 @@ Example:
      In [4]: stitches.expect.Expect.match(con, re.compile('.*release ([0-9,\.]*).*', re.DOTALL))
      Out[4]: ['6.4']
 
+     # Run a command and expect an exit status (0 by default)
+     In [5]: stitches.expect.Expect.expect_retval(con "cat /etc/redhat-release /foo")
+     ---------------------------------------------------------------------------
+     ExpectFailed                              Traceback (most recent call last)
+     ...
+     stitches.expect.ExpectFailed: Got 1 exit status (0 expected)
+     cmd: cat /etc/redhat-release /foo
+     stdout: Red Hat Enterprise Linux release 8.0 Beta (Ootpa)
+
+     stderr: cat: /foo: No such file or directory
+
 Structure
 ---------
 `Structure` class is being used to create whole testing setup with multiple hosts performing different roles. Structure is usually created based on YAML file:

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@
 from setuptools import setup
 
 setup(name='stitches',
-    version='0.12',
+    version='0.13',
     description='Multihost actions toolbox',
     author='Vitaly Kuznetsov',
     author_email='vitty@redhat.com',

--- a/stitches/expect.py
+++ b/stitches/expect.py
@@ -202,8 +202,9 @@ class Expect(object):
             raise ExpectFailed("Got timeout (%i seconds) while executing '%s'"
                                % (timeout, command))
         elif retval != expected_status:
-            raise ExpectFailed("Got %s exit status (%s expected)"
-                               % (retval, expected_status))
+            raise ExpectFailed("Got %s exit status (%s expected)\ncmd: %s\nstdout: %s\nstderr: %s"
+                               % (retval, expected_status, connection.last_command,
+                                  connection.last_stdout, connection.last_stderr))
         if connection.output_shell:
             sys.stdout.write("Run '%s', got %i return value\n"
                              % (command, retval))


### PR DESCRIPTION
Previously, when you ran `expect_retval()` and the command didn't exit with the expected status, you didn't know why as no output was provided. This commit adds the command, the stdout, and the stderr to the traceback for easier debugging.