### PR TITLE
connection.py:check type of instance first

### DIFF
--- a/stitches/connection.py
+++ b/stitches/connection.py
@@ -55,11 +55,11 @@ class Connection(object):
         """
         self.logger = logging.getLogger('stitches.connection')
 
-        if type(instance) == str:
+        if type(instance) == dict:
+            self.parameters = instance.copy()
+        else:
             self.parameters = {'private_hostname': instance,
                                'public_hostname': instance}
-        else:
-            self.parameters = instance.copy()
         # hostname is set for compatibility issues only, will be deprecated
         # in future
         if 'private_hostname' in self.parameters.keys() and \


### PR DESCRIPTION
With this patch, it does copy() method only when the instance type is dict.
It woulbe be more reasonable than checking str or unicode type.

In dva test, hit the following unhandled exception:
    , line 14, in connection\n    con = stitches.Connection(host, user, key)\n  File\
    \ \"/usr/lib/python2.7/site-packages/stitches-0.13-py2.7.egg/stitches/connection.py\"\
    , line 62, in __init__\n    self.parameters = instance.copy()\nAttributeError:\
    \ 'unicode' object has no attribute 'copy'\n"
  stage_name: attempt_ssh

Signed-off-by: Xiao Liang <xiliang@redhat.com>