### PR TITLE
avoid problematic language

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -1,6 +1,3 @@
-[MASTER]
-
-
 [MESSAGES CONTROL]
 
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@
 from setuptools import setup
 
 setup(name='stitches',
-    version='0.15',
+    version='0.16',
     description='Multihost actions toolbox',
     author='Vitaly Kuznetsov',
     author_email='vitty@redhat.com',

--- a/stitches/connection.py
+++ b/stitches/connection.py
@@ -194,9 +194,9 @@ class Connection(object):
 import os
 print(os.environ)
 from rpyc.utils.server import ThreadedServer
-from rpyc import SlaveService
+from rpyc import ClassicService
 import sys
-t = ThreadedServer(SlaveService, hostname = 'localhost', port = 0, reuse_addr = True)
+t = ThreadedServer(ClassicService, hostname = 'localhost', port = 0, reuse_addr = True)
 fd = open('""" + pid_filename + r"""', 'w')
 fd.write(str(t.port))
 fd.close()


### PR DESCRIPTION
@liangxiao1 could you please check if this change (especially the change made to `rpyc()`) doesn't break your tests?

I'm asking you because you kindly submitted a few pull requests for python-stitches recently, so I consider you an active user. I've verified that `con.rpyc.builtins.open('/etc/redhat-release')`, as used in usage examples, still works, but I'd like to double-check for regressions. For example, if you use python-stitches in `dva`, please try the patched python-stitches code with `dva`.

I'll update the version string and merge the changes if all goes well.